### PR TITLE
#100 - Change of ffi gem version

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     colorator (1.1.0)
     faraday (0.12.0.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18)
+    ffi (1.9.25)
     forwardable-extended (2.6.0)
     jekyll (3.4.3)
       addressable (~> 2.4)


### PR DESCRIPTION
ffi gem version 1.9.18 has security problems, so I update it to version 1.9.25 that seems to have no vulnerability 