### PR TITLE
Refactor/create favorite controller

### DIFF
--- a/indicaAi/app/controllers/favorite_locals_controller.rb
+++ b/indicaAi/app/controllers/favorite_locals_controller.rb
@@ -2,11 +2,15 @@
 class FavoriteLocalsController < ApplicationController
   # Post /favorite/create
   def create
-    @favorite = FavoriteLocal.new(favorite_params)
-    if @favorite.save
-      response_success('SUCCESS', 'Saved favorite', @favorite, 200)
+    if (user = UserIdentifier.find_by(identifier: params[:user_identifier]))
+      @favorite = FavoriteLocal.new(favorite_create_params(params, user))
+      if @favorite.save
+        response_success('SUCCESS', 'Favorite saved', [@favorite, user], 200)
+      else
+        response_error('ERROR', 'Favorite not saved', 422)
+      end
     else
-      response_error('ERROR', 'Favorite not saved', 422)
+      response_error('ERROR', 'User not found', 422)
     end
   end
 
@@ -16,7 +20,7 @@ class FavoriteLocalsController < ApplicationController
 
     if @favorite.nil?
       response_error('ERROR', 'Favorite not found', 404)
-    elsif @favorite.update(favorite_params)
+    elsif @favorite.update(favorite_update_params)
       response_success('SUCCESS', 'Updated favorite', @favorite, 200)
     else
       response_error('ERROR', 'Favorite not updated', 422)
@@ -38,7 +42,14 @@ class FavoriteLocalsController < ApplicationController
 
   private
 
-  def favorite_params
+  def favorite_create_params(params, user)
+    {
+      user_identifier_id: user.id,
+      local_id: params[:local_id]
+    }
+  end
+
+  def favorite_update_params
     params.permit(:user_identifier_id, :local_id)
   end
 end

--- a/indicaAi/app/controllers/favorite_locals_controller.rb
+++ b/indicaAi/app/controllers/favorite_locals_controller.rb
@@ -4,13 +4,12 @@ class FavoriteLocalsController < ApplicationController
   def create
     if (user = UserIdentifier.find_by(identifier: params[:user_identifier]))
       @favorite = FavoriteLocal.new(favorite_create_params(params, user))
+      result = { favorite: @favorite, user: user }
       if @favorite.save
-        response_success('SUCCESS', 'Favorite saved', [@favorite, user], 200)
-      else
-        response_error('ERROR', 'Favorite not saved', 422)
+        response_success('SUCCESS', 'Favorite saved', result, 200)
+      else response_error('ERROR', 'Favorite not saved', 422)
       end
-    else
-      response_error('ERROR', 'User not found', 422)
+    else response_error('ERROR', 'User not found', 422)
     end
   end
 

--- a/indicaAi/app/controllers/user_identifiers_controller.rb
+++ b/indicaAi/app/controllers/user_identifiers_controller.rb
@@ -15,8 +15,12 @@ class UserIdentifiersController < ApplicationController
 
   # list all favorites of user
   def list_favorites
-    @favorites = UserIdentifier.find_favorites(params[:id])
-    @user = UserIdentifier.find_by_id(params[:id])
-    json_response(user: @user, favorites: @favorites)
+    if (user = UserIdentifier.find_by(identifier: params[:user_identifier]))
+      @favorites = UserIdentifier.find_favorites(user.id)
+      @user = UserIdentifier.find_by_id(user.id)
+      json_response(user: @user, favorites: @favorites)
+    else
+      response_error('ERROR', 'User not found', 422)
+    end
   end
 end

--- a/indicaAi/config/routes.rb
+++ b/indicaAi/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get '/locals/:id_local/ratings', to: 'locals#show_ratings'
   get '/users', to: 'user_identifiers#index'
   get '/users/:id', to: 'user_identifiers#show_user'
-  get '/users/:id/favorites/', to: 'user_identifiers#list_favorites'
+  get '/users/:user_identifier/favorites/', to: 'user_identifiers#list_favorites'
   get '/categories', to: 'categories#index'
   get '/categories/:id', to: 'categories#show_category'
   get '/categories/:id/locals', to: 'categories#list_locals'

--- a/indicaAi/spec/controllers/favorite_locals_controller_spec.rb
+++ b/indicaAi/spec/controllers/favorite_locals_controller_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe FavoriteLocalsController, type: :controller do
       post :create, params: valid_params
       expect(response).not_to be_success
     end
+    it 'should return error user not found' do
+      valid_params['user_identifier'] = nil
+      post :create, params: valid_params
+      expect(response).to have_http_status(422)
+    end
   end
 end
 

--- a/indicaAi/spec/controllers/favorite_locals_controller_spec.rb
+++ b/indicaAi/spec/controllers/favorite_locals_controller_spec.rb
@@ -7,14 +7,13 @@ RSpec.describe FavoriteLocalsController, type: :controller do
   let!(:valid_params) do
     {
       'local_id' => local_test.id,
-      'user_identifier_id' => user_test.id
+      'user_identifier' => user_test.identifier
     }
   end
   describe 'Post create' do
     it 'should returns success saved favorite' do
       post :create, params: valid_params
       expect(response).to be_success
-      expect(assigns(:favorite)).to have_attributes(valid_params)
       expect(assigns(:favorite)).to be_persisted
       expect(assigns(:favorite)).to be_a(FavoriteLocal)
       expect(assigns(:favorite)).not_to eq(nil)

--- a/indicaAi/spec/controllers/user_identifiers_controller_spec.rb
+++ b/indicaAi/spec/controllers/user_identifiers_controller_spec.rb
@@ -28,18 +28,14 @@ RSpec.describe UserIdentifiersController, type: :controller do
 end
 
 RSpec.describe UserIdentifiersController, type: :controller do
-  let!(:users_test) { create(:user_identifier) }
+  let!(:users_test) { create_list(:user_identifier, 10) }
+  let!(:user) { users_test.first }
   let!(:favorites_test) do
-    create_list(:favorite_local, 10, user_identifier: users_test)
+    create_list(:favorite_local, 10, user_identifier: user)
   end
   describe 'GET list_favorites' do
     it 'should returns list of favorites to assign @favorites ' do
-      get :list_favorites, params: { id: users_test.id }
-      should route(
-        :get, "/users/#{users_test.id}/favorites"
-      ).to(
-        action: :list_favorites, id: users_test.id
-      )
+      get :list_favorites, params: { user_identifier: user.identifier }
       expect(response).to be_success
       assert assigns(:favorites) == favorites_test
       expect(assigns(:favorites).length).to eq(10)

--- a/indicaAi/spec/requests/favorite_locals_spec.rb
+++ b/indicaAi/spec/requests/favorite_locals_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Local API', type: :request do
   let!(:valid_params) do
     {
       'local_id' => local_test.id,
-      'user_identifier_id' => user_test.id
+      'user_identifier' => user_test.identifier
     }
   end
   describe 'POST /favorites' do
@@ -14,7 +14,6 @@ RSpec.describe 'Local API', type: :request do
       expect do
         post '/favorites', params: valid_params
       end.to change(FavoriteLocal, :count).by(+1)
-      expect(FavoriteLocal.last).to have_attributes(valid_params)
       expect(response).to have_http_status(200)
     end
     it 'should returns error not created favorite' do

--- a/indicaAi/spec/requests/user_identifiers_spec.rb
+++ b/indicaAi/spec/requests/user_identifiers_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'User Controller', type: :request do
     create_list(:favorite_local, 10, user_identifier: user_test)
   end
   describe 'GET /users/:id/favorites' do
-    before { get "/users/#{user_test.id}/favorites" }
+    before { get "/users/#{user_test.identifier}/favorites" }
     it 'return favorites by user in json' do
       expect(json).not_to be_empty
       expect(json['favorites'][0]['user_identifier_id']).to eq(user_test.id)


### PR DESCRIPTION
Fixes #

## Alterações realizadas

  - Criação dos favoritos utilizando nas requests o identifier do usuário obtido no front  e realizado verificação antes se esse usuário já está cadastrado no back ao invés da request json utilizar o id do usuário no rails diretamente.
  - Listagem de favoritos também utilizando o identifier do usuário do front.
